### PR TITLE
Add subscript operator to Expression to access sub-expressions by name

### DIFF
--- a/include/peg_parser/interpreter.h
+++ b/include/peg_parser/interpreter.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <iterator>
-#include <type_traits>
 #include <optional>
+#include <type_traits>
 
 #include "parser.h"
 
@@ -60,7 +60,8 @@ namespace peg_parser {
         return interpreter.interpret(syntaxTree->inner[idx]);
       }
       std::optional<Expression> operator[](std::string_view name) const {
-        auto it = std::find_if(syntaxTree->inner.begin(), syntaxTree->inner.end(), [name](auto st) { return st->rule->name == name; });
+        auto it = std::find_if(syntaxTree->inner.begin(), syntaxTree->inner.end(),
+                               [name](auto st) { return st->rule->name == name; });
         if (it != syntaxTree->inner.end()) {
           return interpreter.interpret(*it);
         }

--- a/include/peg_parser/interpreter.h
+++ b/include/peg_parser/interpreter.h
@@ -2,6 +2,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include <optional>
 
 #include "parser.h"
 

--- a/include/peg_parser/interpreter.h
+++ b/include/peg_parser/interpreter.h
@@ -58,6 +58,13 @@ namespace peg_parser {
       Expression operator[](size_t idx) const {
         return interpreter.interpret(syntaxTree->inner[idx]);
       }
+      std::optional<Expression> operator[](std::string_view name) const {
+        auto it = std::find_if(syntaxTree->inner.begin(), syntaxTree->inner.end(), [name](auto st) { return st->rule->name == name; });
+        if (it != syntaxTree->inner.end()) {
+          return interpreter.interpret(*it);
+        }
+        return {};
+      }
       iterator begin() const { return iterator(*this, 0); }
       iterator end() const { return iterator(*this, size()); }
 

--- a/test/source/parser.cpp
+++ b/test/source/parser.cpp
@@ -284,3 +284,26 @@ TEST_CASE("Documentation Example") {
   REQUIRE(g.run("1 - 2*3/2 + 4") == Approx(2));
   REQUIRE(g.run("1 + 2 * (3+4)/ 2 - 3") == Approx(5));
 }
+
+TEST_CASE("Subscript Operators") {
+  ParserGenerator<std::string> program;
+  program.setSeparator(program["Whitespace"] << "[\t ]");
+
+  program["Word"] << "[a-z]+";
+  program["Yell"] << "[A-Z]+";
+  program["Number"] << "[0-9]+";
+  program["IntSubscript"] << "Word Yell? Number" >> [](auto e) { return e[1].string(); };
+  program["StringSubscriptOptional"] << "Number Yell? Word" >> [](auto e) { 
+    if( auto expr = e["Yell"] ) 
+      return expr->string();
+    return std::string();
+  };
+  program["Start"] << "IntSubscript | StringSubscriptOptional";
+
+  program.setStart(program["Start"]);
+
+  REQUIRE(program.run("ab 0") == "0");
+  REQUIRE(program.run("ab CD 1") == "CD");
+  REQUIRE(program.run("2 ef") == "");
+  REQUIRE(program.run("2 GH ij") == "GH");
+}

--- a/test/source/parser.cpp
+++ b/test/source/parser.cpp
@@ -293,9 +293,8 @@ TEST_CASE("Subscript Operators") {
   program["Yell"] << "[A-Z]+";
   program["Number"] << "[0-9]+";
   program["IntSubscript"] << "Word Yell? Number" >> [](auto e) { return e[1].string(); };
-  program["StringSubscriptOptional"] << "Number Yell? Word" >> [](auto e) { 
-    if( auto expr = e["Yell"] ) 
-      return expr->string();
+  program["StringSubscriptOptional"] << "Number Yell? Word" >> [](auto e) {
+    if (auto expr = e["Yell"]) return expr->string();
     return std::string();
   };
   program["Start"] << "IntSubscript | StringSubscriptOptional";

--- a/test/source/parser.cpp
+++ b/test/source/parser.cpp
@@ -286,23 +286,12 @@ TEST_CASE("Documentation Example") {
 }
 
 TEST_CASE("Subscript Operators") {
-  ParserGenerator<std::string> program;
-  program.setSeparator(program["Whitespace"] << "[\t ]");
-
+  ParserGenerator<bool> program;
   program["Word"] << "[a-z]+";
   program["Yell"] << "[A-Z]+";
-  program["Number"] << "[0-9]+";
-  program["IntSubscript"] << "Word Yell? Number" >> [](auto e) { return e[1].string(); };
-  program["StringSubscriptOptional"] << "Number Yell? Word" >> [](auto e) {
-    if (auto expr = e["Yell"]) return expr->string();
-    return std::string();
-  };
-  program["Start"] << "IntSubscript | StringSubscriptOptional";
-
+  program["Start"] << "Word | Yell" >> [](auto e) { return bool(e["Yell"]); };
   program.setStart(program["Start"]);
 
-  REQUIRE(program.run("ab 0") == "0");
-  REQUIRE(program.run("ab CD 1") == "CD");
-  REQUIRE(program.run("2 ef") == "");
-  REQUIRE(program.run("2 GH ij") == "GH");
+  REQUIRE(!program.run("hello"));
+  REQUIRE(program.run("HELLO"));
 }


### PR DESCRIPTION
Hi there!
It might be just me, but accessing certain sub-expressions of a rule by name seems very handy for me, especially with very complicated rules. So I added this. It seems to work quite well. Especially the std::optional makes parsing expressions with optional expressions much simpler.